### PR TITLE
Return a EntityCategory instance instead of str

### DIFF
--- a/custom_components/scheduler/switch.py
+++ b/custom_components/scheduler/switch.py
@@ -318,7 +318,7 @@ class ScheduleEntity(ToggleEntity):
     @property
     def EntityCategory(self):
         """Return EntityCategory."""
-        return EntityCategory.CONFIG
+        return EntityCategory(EntityCategory.CONFIG)
 
     @property
     def weekdays(self):


### PR DESCRIPTION
With HA 2022.04 the entity category is enforced to be an instance of `EntityCategory`: https://github.com/home-assistant/core/pull/69015

Without this fix, the following error prevents the component from working correctly:
![image](https://user-images.githubusercontent.com/2053039/162214307-8aab2d1d-9859-4d48-8900-d06f54eb470f.png)
