### PR TITLE
Simplify integration name

### DIFF
--- a/custom_components/scheduler/manifest.json
+++ b/custom_components/scheduler/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "scheduler",
-  "name": "Scheduler integration",
+  "name": "Scheduler",
   "documentation": "https://github.com/nielsfaber/scheduler-component",
   "issue_tracker": "https://github.com/nielsfaber/scheduler-component/issues",
   "version": "v0.0.0",


### PR DESCRIPTION
I propose that the integration name be simplified to just "Scheduler" rather than "Scheduler integration". This gives a cleaner look in the HA interface.

Before:
![integration card with name set to "Scheduler integration"](https://user-images.githubusercontent.com/2292715/206075371-af8018ec-c7af-46ca-97ad-94f10958c648.png)

After:
![integration card with name set to "Scheduler"](https://user-images.githubusercontent.com/2292715/206075445-dad13c40-eb38-447c-af10-e360e0c046d4.png)
