### PR TITLE
Remove deprecated `hass.components` and use package function

### DIFF
--- a/custom_components/scheduler/manifest.json
+++ b/custom_components/scheduler/manifest.json
@@ -3,7 +3,7 @@
   "name": "Scheduler",
   "codeowners": ["@nielsfaber"],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": ["http", "websocket_api"],
   "documentation": "https://github.com/nielsfaber/scheduler-component",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/nielsfaber/scheduler-component/issues",

--- a/custom_components/scheduler/websockets.py
+++ b/custom_components/scheduler/websockets.py
@@ -232,7 +232,8 @@ async def async_register_websockets(hass):
     hass.http.register_view(SchedulesListView)
 
     # pass list of schedules to frontend
-    hass.components.websocket_api.async_register_command(
+    websocket_api.async_register_command(
+        hass,
         const.DOMAIN,
         websocket_get_schedules,
         websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -243,7 +244,8 @@ async def async_register_websockets(hass):
     )
 
     # pass single schedule to frontend
-    hass.components.websocket_api.async_register_command(
+    websocket_api.async_register_command(
+        hass,
         "{}/item".format(const.DOMAIN),
         websocket_get_schedule_item,
         websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -255,7 +257,8 @@ async def async_register_websockets(hass):
     )
 
     # pass list of tags to frontend
-    hass.components.websocket_api.async_register_command(
+    websocket_api.async_register_command(
+        hass,
         "{}/tags".format(const.DOMAIN),
         websocket_get_tags,
         websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(


### PR DESCRIPTION
We'll deprecate the use of `hass.components` as of Home Assistant 2024.3 (https://developers.home-assistant.io/blog/2024/02/27/deprecate-bind-hass-and-hass-components/), it is recommended to use the function from the package directly and pass the `hass` object as the first parameter. This is not a breaking change for 2024.3.

This PR therefore calls `async_register_command` from the `websocket_api` package.