### PR TITLE
Replace deprecated function

### DIFF
--- a/custom_components/scheduler/__init__.py
+++ b/custom_components/scheduler/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.event import (
     async_call_later,
-    async_track_state_change,
+    async_track_state_change_event,
     async_track_point_in_time,
 )
 
@@ -425,7 +425,7 @@ class SchedulerCoordinator(DataUpdateCoordinator):
             await self.async_reset_workday_timer()
             async_dispatcher_send(self.hass, const.EVENT_WORKDAY_SENSOR_UPDATED)
 
-        self._workday_tracker = async_track_state_change(
+        self._workday_tracker = async_track_state_change_event(
             self.hass, const.WORKDAY_ENTITY, async_workday_state_updated
         )
         await self.async_reset_workday_timer()

--- a/custom_components/scheduler/actions.py
+++ b/custom_components/scheduler/actions.py
@@ -27,7 +27,7 @@ from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
 )
 from homeassistant.helpers.event import (
-    async_track_state_change,
+    async_track_state_change_event,
     async_call_later,
 )
 from homeassistant.helpers.service import async_call_from_config
@@ -398,7 +398,7 @@ class ActionQueue:
         watched_entities = list(set(self._condition_entities + self._action_entities))
         if len(watched_entities):
             self._listeners.append(
-                async_track_state_change(
+                async_track_state_change_event(
                     self.hass, watched_entities, async_entity_changed
                 )
             )
@@ -585,7 +585,7 @@ class ActionQueue:
                         await self.async_process_queue(task_idx + 1)
 
                 if action[CONF_SERVICE] == ACTION_WAIT_STATE_CHANGE:
-                    self._state_update_listener = async_track_state_change(
+                    self._state_update_listener = async_track_state_change_event(
                         self.hass, action[ATTR_ENTITY_ID], async_entity_changed
                     )
                 return

--- a/custom_components/scheduler/timer.py
+++ b/custom_components/scheduler/timer.py
@@ -14,7 +14,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers.event import (
     async_track_point_in_time,
-    async_track_state_change,
+    async_track_state_change_event,
 )
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -206,7 +206,7 @@ class TimerHandler:
                     # only reschedule if this doesnt cause the timer to shift to another hour (due to DST change)
                     await self.async_start_timer()
 
-            self._sun_tracker = async_track_state_change(
+            self._sun_tracker = async_track_state_change_event(
                 self.hass, const.SUN_ENTITY, async_sun_updated
             )
         else:


### PR DESCRIPTION
Fixes #354 

I don't know how you best handle deprecated functions like this to maintain compatibility, this seems to have been around for a long time though so probably fine to just merge and not even mention it

https://developers.home-assistant.io/blog/2024/04/13/deprecate_async_track_state_change/