### PR TITLE
Add reload_storage, delete_schedule_by_id services to be able to manually fix scheduler.storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Any entity in HA can be used for making a scheduler entity, together with any se
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=nielsfaber&repository=scheduler-component&category=integration)
 
-Make sure you have HACS installed. If you don't, run `wget -O - https://get.hacs.xyz | bash -` in HA.  
+Make sure you have HACS installed. If you don't, run `wget -O - https://get.hacs.xyz | bash -` in HA.
 Choose Integrations under HACS. Click the '+' button on the bottom of the page, search for "scheduler component", choose it, and click install in HACS.
 
 #### Option 2: Manual
@@ -70,7 +70,7 @@ The entities in HA are created from the `scheduler.storage` file upon (re)starti
 ## Scheduler entities
 Entities that are part of the scheduler integrations will have entity id following according to pattern `switch.schedule_<token>`, where `<token>` is a randomly generated 6 digit code.
 
-You can treat these entities in the same way as other `switch` entities in HA, meaning that you could place them in any Lovelace card for quick access. 
+You can treat these entities in the same way as other `switch` entities in HA, meaning that you could place them in any Lovelace card for quick access.
 
 ### States
 A scheduler entity can have the following states:
@@ -87,7 +87,7 @@ A scheduler entity can have the following states:
 Since schedules follow the `switch` platform, you can use the `switch.turn_on` and `switch.turn_off` services to enable and disable schedules.
 
 In addition, the following services are available.
-Note that this component is meant to be used together with the [Lovelace scheduler card](https://github.com/nielsfaber/scheduler-card), which handles some of the data validation. 
+Note that this component is meant to be used together with the [Lovelace scheduler card](https://github.com/nielsfaber/scheduler-card), which handles some of the data validation.
 
 
 #### scheduler.add
@@ -105,12 +105,12 @@ Add a new scheduler entity.
 
 #### scheduler.edit
 Update the configuration of an existing scheduler entity.
-Overwrites the old value. 
+Overwrites the old value.
 
 The service parameters are the same as for `scheduler.add`, except that the `entity_id` needs to be provided of the schedule which needs to be modified.
 
 Note that only the parameters that should be changed have to be provided, if a parameter is not provided, the previous value will be kept.
-                                                                                                                                                 
+
 #### scheduler.remove
 Remove a scheduler entity.
 
@@ -118,7 +118,7 @@ Remove a scheduler entity.
 | ----------- | ------ | ----------------- | --------------------------------- | ----------------------------- |
 | `entity_id` | string | required          | Entity ID of the scheduler entity | e.g. `switch.schedule_123456` |
 
-                                                                     
+
 #### scheduler.copy
 Duplicate a scheduler entity.
 
@@ -129,7 +129,12 @@ Duplicate a scheduler entity.
 
 
 
+#### scheduler.reload_storage
+
+Reload scheduler storage from disk to refresh data.
+
 #### scheduler.run_action
+
 Manually trigger a schedule.
 
 | field             | Type    | Optional/required | Description                                                      | Remarks                                                                                                                                                                                                                                                                                                                     |
@@ -155,7 +160,7 @@ A timeslot defines the timepoints on which a schedule is triggered, together wit
 **Note**:
 
 To guarantee compatibility with the scheduler-card, the following conditions need to be met:
-1. A schedule must exist of either: 
+1. A schedule must exist of either:
   <ul>
     <li>A single timeslot with only <code>start</code> time</li>
     <li>A list timeslots which ALL have <code>start</code>  and <code>stop</code> time, which are non overlapping and are not relative to sun.</li>
@@ -165,7 +170,7 @@ To guarantee compatibility with the scheduler-card, the following conditions nee
 
 
 3. Actions list may only consist of a single service/service_data combination (multiple actions may only have different entity_id).
-  
+
 
 ### Condition
 
@@ -180,7 +185,7 @@ Conditions are currently limited to checking the state of entities.
 
 ### Action
 
-An action is a combination of a HA service with entity_id. 
+An action is a combination of a HA service with entity_id.
 See Developer Tools -> Services in HA for available actions and info on valid parameters.
 
 | Name           | Type   | Optional/required | Description                                        | Remarks                   |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Add a new scheduler entity.
 | `repeat_type` | string | optional          | Control repeat behaviour after triggering.                            | Valid values are: <ul><li>`repeat`: (default value) schedule will loop after triggering</li><li>`single`: schedule will delete itself after triggering</li><li>`pause`: schedule will turn off after triggering, can be reset by turning on</li></ul> |
 | `name`        | string | optional          | Friendly name for the schedule entity.                                | The name will also be used for the entity_id of the schedule.<br> Default value is `Schedule #abcdef                     ` where `abcdef`=random generated sequence.                                                                                  |
 
+#### scheduler.delete_schedule_by_id
+
+Remove a scheduler entity by id.
+
+| field       | Type   | Optional/required | Description                       | Remarks                       |
+| ----------- | ------ | ----------------- | --------------------------------- | ----------------------------- |
+| `schedule_id` | string | required          | Schedule ID | e.g. `94a36e` | |
 
 #### scheduler.edit
 Update the configuration of an existing scheduler entity.

--- a/custom_components/scheduler/__init__.py
+++ b/custom_components/scheduler/__init__.py
@@ -171,6 +171,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async_service_enable_all
     )
 
+    async def async_service_reload_storage(service):
+        """Reload scheduler storage from disk."""
+        await coordinator.async_reload_storage()
+
+    hass.services.async_register(
+        const.DOMAIN,
+        const.SERVICE_RELOAD_STORAGE,
+        async_service_reload_storage
+    )
+
     return True
 
 
@@ -444,3 +454,11 @@ class SchedulerCoordinator(DataUpdateCoordinator):
         """disables all schedules"""
         for schedule in self.hass.data[const.DOMAIN]["schedules"].values():
             await schedule.async_turn_off()
+
+    async def async_reload_storage(self):
+        """Reload scheduler storage from disk."""
+        _LOGGER.info("Reloading scheduler storage from disk")
+        await self.store.async_load()
+        _LOGGER.info("Scheduler storage reloaded successfully")
+        # Notify listeners that storage has been reloaded
+        async_dispatcher_send(self.hass, const.EVENT_STARTED)

--- a/custom_components/scheduler/const.py
+++ b/custom_components/scheduler/const.py
@@ -53,6 +53,7 @@ SERVICE_ADD = "add"
 SERVICE_COPY = "copy"
 SERVICE_DISABLE_ALL = "disable_all"
 SERVICE_ENABLE_ALL = "enable_all"
+SERVICE_RELOAD_STORAGE = "reload_storage"
 
 OffsetTimePattern = re.compile(r"^([a-z]+)([-|\+]{1})([0-9:]+)$")
 DatePattern = re.compile(r"^[0-9]+\-[0-9]+\-[0-9]+$")

--- a/custom_components/scheduler/const.py
+++ b/custom_components/scheduler/const.py
@@ -54,6 +54,7 @@ SERVICE_COPY = "copy"
 SERVICE_DISABLE_ALL = "disable_all"
 SERVICE_ENABLE_ALL = "enable_all"
 SERVICE_RELOAD_STORAGE = "reload_storage"
+SERVICE_DELETE_BY_ID = "delete_schedule_by_id"
 
 OffsetTimePattern = re.compile(r"^([a-z]+)([-|\+]{1})([0-9:]+)$")
 DatePattern = re.compile(r"^[0-9]+\-[0-9]+\-[0-9]+$")

--- a/custom_components/scheduler/services.yaml
+++ b/custom_components/scheduler/services.yaml
@@ -178,3 +178,7 @@ disable_all:
 enable_all:
   name: Enable All
   description:  Enables all schedules
+
+reload_storage:
+  name: Reload Storage
+  description: Reload scheduler storage from disk to refresh data

--- a/custom_components/scheduler/services.yaml
+++ b/custom_components/scheduler/services.yaml
@@ -182,3 +182,15 @@ enable_all:
 reload_storage:
   name: Reload Storage
   description: Reload scheduler storage from disk to refresh data
+
+delete_schedule_by_id:
+  name: Delete Schedule by ID
+  description: Delete a schedule by its schedule_id (works for broken entities)
+  fields:
+    schedule_id:
+      name: Schedule ID
+      description: The schedule_id of the schedule to delete
+      example: "7e1ad5"
+      required: true
+      selector:
+        text:


### PR DESCRIPTION
In Home Assistant OS installation it is difficult to modify scheduler.storage file and apply changes. HA restart causes saving current state to file and all previously made changes are lost.

reload_storage service just run `store.async_load()` method and synchronize data from disk and in memory.

Service can be run from scripts, automations accordingly to the needs.

This PR is caused by scheduler-card component instability. It also provides ability to making repetitive changes using text editor.

Some formatting changes are also included.